### PR TITLE
Rename shuttle service to repo name

### DIFF
--- a/shuttle.yaml
+++ b/shuttle.yaml
@@ -1,7 +1,7 @@
 plan: false
 vars:
   squad: nasa
-  service: network-multitool
+  service: flux2-lab
   service-count: 255
   docker:
     image: praqma/network-multitool


### PR DESCRIPTION
Currently in backstage the repo is served as network-multitool which doesnt make that much sense.
This change renames it to what the repo represents instead.